### PR TITLE
Add id for internal rankings to work.

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ module.exports = () => str => got('emoji.getdango.com/api/emoji', {
     q: str
   }
 }).then(res => res.body.results.map(x => ({
+  id: x.text,
   icon: 'fa-smile-o',
   title: x.text,
   subtitle: 'Select to copy to the clipboard',


### PR DESCRIPTION
When you click on results often enough they get sorted higher by Zazu, but you
need an `id` attribute for this to work correctly.